### PR TITLE
NICE-66844 Undefined variable $path

### DIFF
--- a/src/Resource/FilePlugin.php
+++ b/src/Resource/FilePlugin.php
@@ -56,6 +56,7 @@ class FilePlugin extends BasePlugin {
 	 * @param Source $source source object
 	 */
 	public function populateTimestamp(Source $source) {
+		$path = false;
 		if (!$source->exists && $path = $this->getFilePath($source->name, $source->getSmarty(), $source->isConfig)) {
 			$source->timestamp = $source->exists = is_file($path);
 		}


### PR DESCRIPTION
### Summary

This PR initializes the `$path` variable to prevent an "undefined variable" warning when `$source->exists` is `true`.

### Changes

- Added `$path = null;` to ensure `$path` is always defined.

### Impact

Fixes the warning `Undefined variable $path in vendor/smarty/src/Resource/FilePlugin.php on line 62`.
